### PR TITLE
Remove SSH Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,5 @@ Terminating the miner:
 ## Monitoring your miners (on a linux host)
 check [MONITORING](/monitoring/MONITORING.md).
 
-WARNING: The scripts installs my own public SSH key. You may want to remove that from your `~/.ssh/authorized_keys` file and replace it with your own for passwordless access.
-
 ### I accept no warranties or liabilities on this repo. It is supplied as a service.
 ### Use at your own risk!!!

--- a/install.sh
+++ b/install.sh
@@ -5,15 +5,6 @@ sudo apt-get -y install libcurl4-openssl-dev libjansson-dev libomp-dev git scree
 wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_arm64.deb
 sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4_arm64.deb
 rm libssl1.1_1.1.0g-2ubuntu4_arm64.deb
-if [ ! -d ~/.ssh ]
-then
-  mkdir ~/.ssh
-  chmod 0700 ~/.ssh
-  cat << EOF > ~/.ssh/authorized_keys
-ssh-rsa AAAAB3NzaC1yc2EAAAABJQAAAQBy6kORm+ECh2Vp1j3j+3F1Yg+EXNWY07HbP7dLZd/rqtdvPz8uxqWdgKBtyeM7R9AC1MW87zuCmss8GiSp2ZBIcpnr8kdMvYuI/qvEzwfY8pjvi2k3b/EwSP2R6/NqgbHctfVv1c7wL0M7myP9Zj7ZQPx+QV9DscogEEfc968RcV9jc+AgphUXC4blBf3MykzqjCP/SmaNhESr2F/mSxYiD8Eg7tTQ64phQ1oeOMzIzjWkW+P+vLGz+zk32RwmzX5V>
-EOF
-  chmod 0600 ~/.ssh/authorized_keys
-fi
 
 if [ ! -d ~/ccminer ]
 then


### PR DESCRIPTION
🔒 Security and Collaboration Enhancement: It appears that the original intention behind including SSH keys in the repository was for automation purposes. However, it's crucial to consider the security implications when sharing scripts with others. In this pull request, I've taken steps to remove the SSH keys from the repository, ensuring that sensitive information remains confidential and reducing potential security risks. While collaboration is key, let's remember to prioritize the security of our codebase and users by following best practices for handling confidential data. 🛡️💼